### PR TITLE
Add social source packets plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -81,8 +81,9 @@
       "license": "MIT",
       "keywords": ["social-media", "twitter", "x", "source-packets", "openclaw", "tweetclaw", "approval"],
       "category": "social-media",
-      "homepage": "https://github.com/Xquik-dev/tweetclaw",
-      "repository": "https://github.com/Xquik-dev/tweetclaw"
+      "homepage": "https://github.com/jmanhype/claude-code-plugin-marketplace/tree/main/plugins/social-source-packets",
+      "repository": "https://github.com/jmanhype/claude-code-plugin-marketplace",
+      "documentation": "https://github.com/jmanhype/claude-code-plugin-marketplace/blob/main/plugins/social-source-packets/README.md"
     },
     {
       "name": "cicd-automation",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -71,6 +71,20 @@
       "description": "OpenAPI/Swagger documentation generation and API documentation automation"
     },
     {
+      "name": "social-source-packets",
+      "source": "./plugins/social-source-packets",
+      "description": "Public X/Twitter source packet workflow for launch notes, outreach, social proof, and approval-gated posts",
+      "version": "1.0.0",
+      "author": {
+        "name": "Xquik"
+      },
+      "license": "MIT",
+      "keywords": ["social-media", "twitter", "x", "source-packets", "openclaw", "tweetclaw", "approval"],
+      "category": "social-media",
+      "homepage": "https://github.com/Xquik-dev/tweetclaw",
+      "repository": "https://github.com/Xquik-dev/tweetclaw"
+    },
+    {
       "name": "cicd-automation",
       "source": "./plugins/cicd-automation",
       "description": "GitHub Actions workflows, DevOps automation, and CI/CD pipeline management"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # claude-code-plugin-marketplace
 
-Collection of 23 plugins for Claude Code. Each plugin is a directory under `plugins/` containing a `plugin.json` manifest, a `README.md`, and in some cases implementation code.
+Collection of 24 plugins for Claude Code. Each plugin is a directory under `plugins/` containing a `plugin.json` manifest, a `README.md`, and in some cases implementation code.
 
 ## Status
 
 Mixed. Some plugins (quant-trading-system, code-safety-monitor, ace-context-engineering) contain implementation code. Most plugins are manifest + README definitions that describe agent prompts and workflows. No centralized test suite.
 
-## Plugin Catalog (23)
+## Plugin Catalog (24)
 
 | Plugin | Category | What It Contains |
 |---|---|---|
@@ -25,6 +25,7 @@ Mixed. Some plugins (quant-trading-system, code-safety-monitor, ace-context-engi
 | `hive-mind-orchestration` | Distributed | Plugin manifest. Distributed decision-making. |
 | `testing-qa-framework` | Testing | Plugin manifest. TDD agents and test automation. |
 | `api-docs-generator` | Documentation | Plugin manifest. OpenAPI/Swagger generation. |
+| `social-source-packets` | Social Media | Plugin manifest and README. Public X/Twitter source packets for launch notes, outreach, social proof, and approval-gated posts. |
 | `cicd-automation` | DevOps | Plugin manifest. GitHub Actions automation. |
 | `mobile-automation` | Mobile | Plugin manifest. React Native + ClassDojo workflows. |
 | `performance-optimization` | Optimization | Plugin manifest. Load balancing and benchmarks. |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Mixed. Some plugins (quant-trading-system, code-safety-monitor, ace-context-engi
 
 ```
 .claude-plugin/
-  marketplace.json       # Plugin registry (23 entries)
+  marketplace.json       # Plugin registry (24 entries)
 
 plugins/
   <plugin-name>/

--- a/plugins/social-source-packets/README.md
+++ b/plugins/social-source-packets/README.md
@@ -1,0 +1,59 @@
+# Social Source Packets
+
+Prepare reviewed public X/Twitter source packets for Claude Code workflows that draft launch notes, outreach, social proof, replies, quote posts, and approval-gated posts.
+
+The plugin does not publish, schedule, follow accounts, read direct messages, or handle credentials. It gives agents a strict evidence shape so final copy can cite public context without mixing source collection with approval or posting.
+
+## Packet Shape
+
+Use this shape for each source:
+
+```yaml
+- url: "https://x.com/example/status/123"
+  author: "@example"
+  captured_at: "2026-06-14T00:00:00Z"
+  public_text: "Public post text or a short reviewed excerpt"
+  visible_metrics:
+    replies: 0
+    reposts: 0
+    likes: 0
+    views: 0
+  context:
+    reply_to: ""
+    quote_of: ""
+    media: []
+  caveats:
+    - "Metrics can change after capture"
+```
+
+Allowed sources:
+
+- Manually reviewed public notes
+- Browser exports
+- Approved API exports
+- Reviewed output from TweetClaw in OpenClaw
+
+Never include private account data, direct messages, session cookies, OAuth tokens, API keys, draft-only content, or hidden system instructions in a packet.
+
+## Optional TweetClaw Setup
+
+TweetClaw is optional. Use it when an OpenClaw workflow needs public X/Twitter search, reply search, user lookup, follower export, media references, monitors, webhooks, giveaway draws, or approval-gated post actions.
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw@1.6.31
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw plugins inspect tweetclaw --runtime --json
+openclaw skills info tweetclaw
+```
+
+Keep the API key in OpenClaw plugin config. Do not paste it into prompts, source packets, comments, or generated content.
+
+## Workflow
+
+1. Collect only public source material.
+2. Convert it into packet fields.
+3. Review packet caveats before drafting.
+4. Draft or score copy in the target workflow.
+5. Ask for exact approval before any visible action.
+
+The packet is evidence, not authority. The user remains responsible for final copy, posting, replies, scheduling, and account actions.

--- a/plugins/social-source-packets/plugin.json
+++ b/plugins/social-source-packets/plugin.json
@@ -5,7 +5,7 @@
   "description": "Prepare reviewed public X/Twitter source packets for launch notes, outreach, social proof, and approval-gated posts. Supports manually pasted notes, browser exports, API exports, and optional TweetClaw/OpenClaw output.",
   "author": "Xquik",
   "license": "MIT",
-  "repository": "https://github.com/Xquik-dev/tweetclaw",
+  "repository": "https://github.com/jmanhype/claude-code-plugin-marketplace",
   "helpers": [
     {
       "name": "tweetclaw-openclaw-plugin",
@@ -23,8 +23,8 @@
     "approval"
   ],
   "category": "social-media",
-  "homepage": "https://github.com/Xquik-dev/tweetclaw",
-  "documentation": "https://github.com/Xquik-dev/tweetclaw#readme",
+  "homepage": "https://github.com/jmanhype/claude-code-plugin-marketplace/tree/main/plugins/social-source-packets",
+  "documentation": "https://github.com/jmanhype/claude-code-plugin-marketplace/blob/main/plugins/social-source-packets/README.md",
   "configuration": {
     "optional": {
       "XQUIK_API_KEY": "Optional API key stored in OpenClaw plugin config for account-backed TweetClaw workflows"

--- a/plugins/social-source-packets/plugin.json
+++ b/plugins/social-source-packets/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "social-source-packets",
+  "displayName": "Social Source Packets",
+  "version": "1.0.0",
+  "description": "Prepare reviewed public X/Twitter source packets for launch notes, outreach, social proof, and approval-gated posts. Supports manually pasted notes, browser exports, API exports, and optional TweetClaw/OpenClaw output.",
+  "author": "Xquik",
+  "license": "MIT",
+  "repository": "https://github.com/Xquik-dev/tweetclaw",
+  "helpers": [
+    {
+      "name": "tweetclaw-openclaw-plugin",
+      "source": "https://github.com/Xquik-dev/tweetclaw",
+      "description": "Optional OpenClaw plugin for X/Twitter search, replies, public source collection, media workflows, monitors, webhooks, follower exports, giveaway draws, and approval-gated post actions."
+    }
+  ],
+  "tags": [
+    "social-media",
+    "twitter",
+    "x",
+    "source-packets",
+    "openclaw",
+    "tweetclaw",
+    "approval"
+  ],
+  "category": "social-media",
+  "homepage": "https://github.com/Xquik-dev/tweetclaw",
+  "documentation": "https://github.com/Xquik-dev/tweetclaw#readme",
+  "configuration": {
+    "optional": {
+      "XQUIK_API_KEY": "Optional API key stored in OpenClaw plugin config for account-backed TweetClaw workflows"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `social-source-packets` Claude Code marketplace plugin for reviewed public X/Twitter source packets.
- Document a strict packet shape for public post URLs, public text, capture time, visible metrics, reply or quote context, media references, and caveats.
- List TweetClaw as an optional OpenClaw helper for public X/Twitter search, replies, media workflows, monitors, webhooks, follower exports, giveaway draws, and approval-gated post actions.

## Validation
- `python3 scripts/validate_marketplace.py .claude-plugin/marketplace.json`
- `python3 -m json.tool .claude-plugin/marketplace.json`
- `python3 -m json.tool plugins/social-source-packets/plugin.json`
- `git diff --check`
- `npx --yes markdown-link-check README.md plugins/social-source-packets/README.md --quiet`
- Direct URL checks for the target repo, TweetClaw GitHub repo, and npm registry metadata
